### PR TITLE
Install bash completion scripts and move gz tool scripts to non-dev package

### DIFF
--- a/ubuntu/debian/libignition-gui-dev.install
+++ b/ubuntu/debian/libignition-gui-dev.install
@@ -3,5 +3,3 @@ usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-gui*/*
 usr/share/ignition/ignition-gui[0-99]/ignition-gui*.tag.xml
-usr/share/ignition/gui[0-99].yaml
-usr/lib/ruby/ignition/*

--- a/ubuntu/debian/libignition-gui.install
+++ b/ubuntu/debian/libignition-gui.install
@@ -1,2 +1,5 @@
 usr/lib/*/*.so.*
 usr/lib/*/*/plugins/*
+usr/share/ignition/gui[0-99].yaml
+usr/lib/ruby/ignition/*
+usr/share/gz/*


### PR DESCRIPTION
Installs bash completion scripts to `usr/share/gz`. Also moves gz-tool scripts to non-dev deb packages (Toward https://github.com/gazebo-tooling/release-tools/issues/529)